### PR TITLE
fix: target group healthcheck always not healthy

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -35,7 +35,7 @@ resource "aws_lb" "ecs_alb" {
 
 resource "aws_lb_target_group" "ecs_tg" {
   name     = "spotifind-ecs-tg"
-  port     = 80
+  port     = var.port
   protocol = "HTTP"
   vpc_id   = aws_vpc.main.id
 


### PR DESCRIPTION
ecs logs seem to imply server is running fine

![image](https://github.com/user-attachments/assets/f0083e56-7f34-4b2c-b9df-00d7a929475e)

target group is not detecting it as it is watching port `80` instead of the configured port at `/spotifind/PORT`